### PR TITLE
Button fixed and svg sizing in mobile header also

### DIFF
--- a/components/LayoutWrapper.js
+++ b/components/LayoutWrapper.js
@@ -57,7 +57,7 @@ const LayoutWrapper = ({ children }) => {
 
   return (
     <SectionContainer>
-      <HeaderWrapper className="flex justify-between py-3">
+      <HeaderWrapper className="flex flex-shrink-0 justify-between py-3">
         <div>
           <Link href="/" aria-label={siteMetadata.headerTitle}>
             <div className="flex items-center justify-between">

--- a/components/LayoutWrapper.js
+++ b/components/LayoutWrapper.js
@@ -14,6 +14,7 @@ import styled from 'styled-components'
 const MainWrapper = styled.main`
   @media (max-width: 640px) {
     padding-top: 60px;
+    z-index: 22;
   }
 `
 

--- a/components/LayoutWrapper.js
+++ b/components/LayoutWrapper.js
@@ -22,7 +22,6 @@ const ScaledLightLogo = styled(Logo)`
   @media (max-width: 640px) {
     transform: scale(1.2);
     max-width: 80%;
-    overflow: hidden;
   }
 `
 
@@ -30,7 +29,6 @@ const ScaledDarkLogo = styled(LogoDark)`
   @media (max-width: 640px) {
     transform: scale(1.2);
     max-width: 80%;
-    overflow: hidden;
   }
 `
 const HeaderWrapper = styled.header`
@@ -84,7 +82,6 @@ const LayoutWrapper = ({ children }) => {
       </HeaderWrapper>
       <MainWrapper>{children}</MainWrapper>
       <Footer />
-      {/* </div> */}
     </SectionContainer>
   )
 }

--- a/components/LayoutWrapper.js
+++ b/components/LayoutWrapper.js
@@ -20,14 +20,12 @@ const MainWrapper = styled.main`
 
 const ScaledLightLogo = styled(Logo)`
   @media (max-width: 640px) {
-    transform: scale(1.2);
     max-width: 80%;
   }
 `
 
 const ScaledDarkLogo = styled(LogoDark)`
   @media (max-width: 640px) {
-    transform: scale(1.2);
     max-width: 80%;
   }
 `
@@ -59,7 +57,7 @@ const LayoutWrapper = ({ children }) => {
       <HeaderWrapper className="flex flex-shrink-0 justify-between py-3">
         <div>
           <Link href="/" aria-label={siteMetadata.headerTitle}>
-            <div className="flex items-center justify-between">
+            <div className="flex max-h-40 items-center justify-between">
               <div>{theme === 'dark' ? <ScaledDarkLogo /> : <ScaledLightLogo />}</div>
             </div>
           </Link>

--- a/pages/index.js
+++ b/pages/index.js
@@ -19,6 +19,7 @@ const Button = styled.button`
   font-weight: bold;
   cursor: pointer;
   outline: none;
+  z-index: 11;
 `
 
 const GreenButton = styled.a`

--- a/pages/index.js
+++ b/pages/index.js
@@ -19,7 +19,6 @@ const Button = styled.button`
   font-weight: bold;
   cursor: pointer;
   outline: none;
-  z-index: 11;
 `
 
 const GreenButton = styled.a`


### PR DESCRIPTION
There is option to remove padding from svg logos by only grabbing the `<g>` element in the file, upon checking in browser element.